### PR TITLE
Bugfix: Allowing multiple instances

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,8 +32,7 @@
                 "github.copilot",
                 "github.copilot-chat",
                 "streetsidesoftware.code-spell-checker-cspell-bundled-dictionaries",
-                "codezombiech.gitignore",
-                "ms-python.vscode-python-envs"
+                "codezombiech.gitignore"
             ]
         }
     }

--- a/custom_components/e_redes_smart_metering_plus/manifest.json
+++ b/custom_components/e_redes_smart_metering_plus/manifest.json
@@ -15,5 +15,6 @@
     "issue_tracker": "https://github.com/migueltvms/e_redes_smart_metering_plus/issues",
     "quality_scale": "bronze",
     "requirements": [],
+    "single_config_entry": true,
     "version": "1.1.1"
 }


### PR DESCRIPTION
This pull request makes minor configuration updates to improve development environment consistency and clarify integration behavior.

Development environment configuration:

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L35-R35): Removed the `ms-python.vscode-python-envs` extension from the list of recommended VS Code extensions, likely because it is no longer needed or relevant.

Integration manifest update:

* [`custom_components/e_redes_smart_metering_plus/manifest.json`](diffhunk://#diff-47e4080584bed7881586e5da3c4fae1b86c158144d98d16aadbab0fed8d544e2R18): Added the `single_config_entry` flag to indicate that only one configuration entry is allowed for this integration, improving clarity for users and maintainers.