### PR TITLE
fix: Update sensor units from kWh to Wh and adjust test values for accuracy

### DIFF
--- a/.github/instructions/copilot-instructions.md
+++ b/.github/instructions/copilot-instructions.md
@@ -14,19 +14,23 @@ This integration is fully automatic. When the user installs it, it creates a web
 
 ```json
 {
-    "clock": "2025-08-01 12:41:10",
-    "cpe": "PT000XXXXXXXXXXXXXXX",
-    "instantaneousActivePowerImport": 85.85,
-    "maxActivePowerImport": 85.75,
-    "maxActivePowerImportTime": "2024-04-29 12:41:10",
-    "activeEnergyImport": 198114.34,
-    "instantaneousActivePowerExport": 64.93,
-    "maxActivePowerExport": 96.86,
-    "maxActivePowerExportTime": "2024-04-29 12:41:10",
-    "activeEnergyExport": 612865.24,
-    "voltageL1": 231.58
+  "cpe": "PT000XXXXXXXXXXXXXXX",
+  "SourceTimestamp": "2025-09-24 18:33:20",
+  "activeEnergyExport": 0,
+  "activeEnergyImport": 14817930,
+  "instantaneousActivePowerExport": 0,
+  "instantaneousActivePowerImport": 2518,
+  "maxActivePowerExport": 0,
+  "maxActivePowerExportTime": "0000-00-00 00:00:00",
+  "maxActivePowerImportTotalLastAverage": 3680,
+  "maxActivePowerImportTotalTime": "2025-09-09 11:45:00",
+  "voltageL1": 237.1,
+  "clock": "2025-09-24 19:33:20"
 }
 ```
+
+### Attention:
+The fields activeEnergyImport and activeEnergyExport are cumulative values in Wh (Watt-hour). The instantaneousActivePowerImport and instantaneousActivePowerExport fields represent the current power in W (Watt). The voltageL1 field represents the voltage in V (Volts).
 
 **Note:**
 The user may have **multiple meters**, each uniquely identified by the `cpe` field.

--- a/custom_components/e_redes_smart_metering_plus/const.py
+++ b/custom_components/e_redes_smart_metering_plus/const.py
@@ -30,7 +30,7 @@ SENSOR_MAPPING = {
     "activeEnergyImport": {
         "name": "Active Energy Import",
         "key": "active_energy_import",
-        "unit": "kWh",
+        "unit": "Wh",
         "device_class": "energy",
         "state_class": "total_increasing",
         "icon": "mdi:counter",
@@ -54,7 +54,7 @@ SENSOR_MAPPING = {
     "activeEnergyExport": {
         "name": "Active Energy Export",
         "key": "active_energy_export",
-        "unit": "kWh",
+        "unit": "Wh",
         "device_class": "energy",
         "state_class": "total_increasing",
         "icon": "mdi:counter",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,10 +21,19 @@ def _mock_cloud(monkeypatch: pytest.MonkeyPatch) -> None:
     Force cloud to appear logged out so the integration falls back to local webhook URLs
     and avoids cloudhook API calls.
     """
-
+    # Mock cloud login status
     monkeypatch.setattr(
         "homeassistant.components.cloud.async_is_logged_in", lambda hass: False,
         raising=True,
+    )
+
+    # Mock cloud setup to prevent initialization errors
+    async def mock_cloud_setup(hass, config):
+        return True
+
+    monkeypatch.setattr(
+        "homeassistant.components.cloud.async_setup", mock_cloud_setup,
+        raising=False,
     )
 
 
@@ -37,7 +46,7 @@ def _auto_enable_custom_integrations(enable_custom_integrations: bool) -> None:
 
 
 @pytest.fixture
-async def config_entry(hass: HomeAssistant) -> AsyncGenerator[MockConfigEntry, None]:
+async def config_entry(hass: HomeAssistant) -> AsyncGenerator[MockConfigEntry]:
     """Create and set up a config entry for the integration."""
 
     entry = MockConfigEntry(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -17,7 +17,8 @@ pytestmark = pytest.mark.asyncio
     "field_name,value",
     [
         ("instantaneousActivePowerImport", 987),
-        ("activeEnergyImport", 12.34),
+        ("activeEnergyImport", 12340),
+        ("activeEnergyExport", 5450),
         ("voltageL1", 230.5),
     ],
 )

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -34,7 +34,11 @@ class DummyRequest:
         },
         {
             "cpe": "ABCDEF",
-            "activeEnergyImport": 5.25,
+            "activeEnergyImport": 5250,
+        },
+        {
+            "cpe": "TEST123",
+            "activeEnergyExport": 3140,
         },
     ],
 )


### PR DESCRIPTION
This pull request updates the integration to correctly handle energy measurement units and clarifies the documentation for incoming webhook data. The most significant changes include switching the internal representation of energy values from kilowatt-hours (kWh) to watt-hours (Wh), updating test data and documentation accordingly, and improving test setup reliability.

**Unit and data format corrections:**

* Changed the unit for `activeEnergyImport` and `activeEnergyExport` from `kWh` to `Wh` in the sensor definitions to match the actual data provided by the integration. [[1]](diffhunk://#diff-0e781d7d0dc3ac51458b92600f0acb141d638a044581a3437e425d5dcb652b63L33-R33) [[2]](diffhunk://#diff-0e781d7d0dc3ac51458b92600f0acb141d638a044581a3437e425d5dcb652b63L57-R57)
* Updated all relevant test data to use integer values in Wh instead of floating-point values in kWh, ensuring consistency with the revised units. [[1]](diffhunk://#diff-34f337d15c61fe0e5066d0d18584404ebf8f349d35318635850ad7289530f330L20-R21) [[2]](diffhunk://#diff-918b137eb0d8626f46dbfa516987605fe72885d847cab7955a400b3f6b136c6dL37-R41)

**Documentation improvements:**

* Revised the JSON example in `.github/instructions/copilot-instructions.md` to reflect the new Wh units and clarified the meaning of each field, including a note about cumulative and instantaneous values.

**Testing and reliability enhancements:**

* Improved the cloud mocking setup in `tests/conftest.py` to prevent initialization errors and ensure tests do not depend on actual cloud connectivity.
* Fixed the signature of the `config_entry` test fixture for compatibility and correctness.